### PR TITLE
Changes to cognate to get to work with sca, and with cross-validate. 

### DIFF
--- a/saborncommands/closest.py
+++ b/saborncommands/closest.py
@@ -38,6 +38,7 @@ class SimpleDonorSearch(Wordlist):
                                in self.iter_rows('doculect', self.family)
                                if lang in self.donors}
         self.best_value = 0
+        self.best_score = 0
         self.best_key = 'threshold'
 
     def train(self, thresholds=None, verbose=False):
@@ -91,6 +92,7 @@ class SimpleDonorSearch(Wordlist):
                 best_e = fs
             if verbose: print("... {0:.2f}".format(fs))
         self.best_value = best_t
+        self.best_score = best_e
 
     def predict(self, donors, targets):
         """


### PR DESCRIPTION
Changes to cognate to get to work with sca, and with cross-validate.  Tweaks to cross-validate and cognate and closest in support of cross-validate.

- Changed cognate in order to get method='sca' to function, after separation of multi-threshold and changes wrt scorer.
- For now added parser arg for method to separate Lex and Sca runs.
- Made cross-validate more abstract wrt its optimization parameter. best_key = 'threshold'. best_value = ...

I'm not really sure about how the test for existing scorer works in 'predict_on_wordlist' since self is not used within 'cognate_based_donor_search' in this context. Lexstat performance poorer than Sca performance here.  I'll do full cross-validate to demonstrate today.
```
        if not hasattr(self, "bscorer"):
            wordlist.get_scorer(runs=self.runs)
```

Since only tweaks, I'll plan to merge later on this today, before experimenting with classifier.