### PR TITLE
Remove mention of LexStat for user access, remove some commented out …

### DIFF
--- a/lexibank_sabor.py
+++ b/lexibank_sabor.py
@@ -1,5 +1,4 @@
 import pathlib
-import collections
 
 import pycldf
 from pylexibank import Dataset as BaseDataset
@@ -153,12 +152,7 @@ class Dataset(BaseDataset):
                                  fwc=forms_with_concepts,
                                  fnc=forms_no_concepts,
                                  b=borrowed, p=bp))
-            args.writer.add_language(
-                    ID=language.id[5:],  # Drop the wold- prefix.
-                    Name=language.name,
-                    Glottocode=language.glottocode,
-                    Latitude=language.latitude,
-                    Longitude=language.longitude)
+
             for form in language.forms_with_sounds:
                 if form.concept and form.concept.concepticon_gloss in concepts:
                     args.writer.add_form_with_segments(

--- a/saborcommands/classifier.py
+++ b/saborcommands/classifier.py
@@ -51,6 +51,7 @@ def one_hot(idx, sz, value=1):
 def tar_one_hot(idx, wl, value=1):
     return one_hot(wl.cols.index(
         wl[idx, "doculect"]), len(wl.cols), value)
+    # return one_hot(int(wl[idx, 'langid'])-1, len(wl.cols), value)
 
 
 class ClassifierBasedBorrowingDetection(LexStat):
@@ -258,13 +259,6 @@ def register(parser):
         help="select similarity functions for use by classifier."
     )
     parser.add_argument(
-        "--method",
-        nargs="*",
-        default=None,
-        choices=["sca", "lex", "sca_ov", "sca_lo", "lex_ov", "lex_lo"],
-        help="select similarity methods for use by classifier."
-    )
-    parser.add_argument(
         "--file",
         default=None,  # e.g., "splits/CV10-fold-00-train.tsv"
         help="wordlist filename containing donor and target language tokens."
@@ -315,13 +309,12 @@ def run(args):
     functions = [function[key] for key in args.function]
     bor = ClassifierBasedBorrowingDetection(
         wl, donors=args.donor, clf=SVC(kernel="linear"),
-        funcs=functions, meths=args.method, family="language_family")
+        funcs=functions, family="language_family")
 
     bor.train(verbose=False, log=args.log)
-    args.log.info("Trained with donors {d}, functions {func}, methods {m}".
-                  format(d=bor.donors, func=args.function, m=args.method))
+    args.log.info("Trained with donors {d}, functions {func}".
+                  format(d=bor.donors, func=args.function))
 
-    # args.log.info("Predict")
     bor.predict_on_wordlist(bor)
     test_f1 = evaluate_borrowings_fs(bor, "source_language",
                                      bor.known_donor, bor.donors)
@@ -347,8 +340,8 @@ def run(args):
         bor.predict_on_wordlist(wl)
 
         # Just to remind us after so many cluster messages.
-        args.log.info("Trained with donors {d}, functions {func}, methods {m}".
-                      format(d=bor.donors, func=args.function, m=args.method))
+        args.log.info("Trained with donors {d}, functions {func}".
+                      format(d=bor.donors, func=args.function))
         args.log.info("Train: F1 score {f1:.3f}".format(f1=bor.best_score))
 
         test_f1 = evaluate_borrowings_fs(wl, "source_language",

--- a/saborcommands/evaluate.py
+++ b/saborcommands/evaluate.py
@@ -131,7 +131,6 @@ def evaluate_detection(wl,
         filename = filename.removesuffix('.tsv') + '-evaluate'
         wl.output("tsv", filename=filename, prettify=False, ignore="all")
 
-
     return summary  # Return summary for use in other app.
 
 


### PR DESCRIPTION
Redo on tweaks2 where I added in some files that didn't seem right in the compare.

Remove mention of LexStat for user access, remove some commented out and redundant code, few cosmetic tweaks. [Left internal mention of LexStat as possible base for future functions/methods with LingRex or other.]

No changes in results other than some terminal output. Abandoned idea to add source_word to evaluate wordlist as not sufficiently useful.

Except for revising make file and other ancillary files, I hope there will be no need to change code. 

So tentative code freeze depending on what @LinguList thinks.  Will focus on reading cited references that I haven't read before, writing, performing analysis of errors and writing up something of that process of reviewing wordlist.

Results show no benefit to using langid with 1-hot encoding.  
Brief experiments show that langid doesn't change between train and test wordlists.
Question: Is this true in general (if the same set of languages) or a fluke of how out datasets are ordered?

